### PR TITLE
pylintrc ignore imports. remove unused pylint disable statement.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -250,7 +250,7 @@ ignore-comments=yes
 ignore-docstrings=yes
 
 # Ignore imports when computing similarities.
-ignore-imports=no
+ignore-imports=yes
 
 # Minimum lines number of a similarity.
 min-similarity-lines=4

--- a/adafruit_bh1750.py
+++ b/adafruit_bh1750.py
@@ -37,7 +37,6 @@ from micropython import const
 import adafruit_bus_device.i2c_device as i2c_device
 
 
-# pylint: disable=bad-whitespace
 _BH1750_DEVICE_ID = 0xE1  # Correct content of WHO_AM_I register
 
 # I2C addresses (without R/W bit)


### PR DESCRIPTION
When I ran locally pylint failed for the disable directive that I removed. Poking around a bit it appears that check was removed from  pylint all together in favor of Black and other formatters.