### PR TITLE
Change i2c bus parameter name to match most other libraries

### DIFF
--- a/adafruit_bh1750.py
+++ b/adafruit_bh1750.py
@@ -149,7 +149,7 @@ Resolution.add_values(
 class BH1750:  # pylint:disable=too-many-instance-attributes
     """Library for the BH1750 Sensor
 
-    :param ~busio.I2C i2c_bus: The I2C bus the BH1750 is connected to.
+    :param ~busio.I2C i2c: The I2C bus the BH1750 is connected to.
     :param int address: The I2C device address. Defaults to :const:`0x23`.Can be
                         set to :const:`0x5C` by pulling the address pin high.
 
@@ -182,9 +182,9 @@ class BH1750:  # pylint:disable=too-many-instance-attributes
     mode = RWBitfields(2, 4)
     resolution = RWBitfields(2, 0)
 
-    def __init__(self, i2c_bus, address=_BH1750_DEFAULT_ADDRESS):
+    def __init__(self, i2c, address=_BH1750_DEFAULT_ADDRESS):
 
-        self.i2c_device = i2c_device.I2CDevice(i2c_bus, address)
+        self.i2c_device = i2c_device.I2CDevice(i2c, address)
         self._buffer = bytearray(2)
         self._settings_byte = 0
 


### PR DESCRIPTION
In most libraries offered by CircuitPython the i2c bus parameter name is simply i2c, in this library it isn't.

So, change it to i2c to match others and keep it unified.

Notable examples:
https://github.com/adafruit/Adafruit_CircuitPython_ADS1x15/blob/main/adafruit_ads1x15/ads1x15.py#L69=
https://github.com/adafruit/Adafruit_CircuitPython_BME680/blob/main/adafruit_bme680.py#L454=
https://github.com/adafruit/Adafruit_CircuitPython_TCA9548A/blob/main/adafruit_tca9548a.py#L90=