### PR TITLE
Show info about resolution and mode in docs

### DIFF
--- a/adafruit_bh1750.py
+++ b/adafruit_bh1750.py
@@ -138,7 +138,7 @@ Mode.add_values(
 
 
 class Resolution(CV):
-    """Options for `resolution` Valid values are ``LOW``, ``MID``, and ``HIGH`` """
+    """Options for `resolution` Valid values are ``LOW``, ``MID``, and ``HIGH``"""
 
     pass  # pylint: disable=unnecessary-pass
 

--- a/adafruit_bh1750.py
+++ b/adafruit_bh1750.py
@@ -123,7 +123,7 @@ class RWBitfields:
 
 
 class Mode(CV):
-    """Options for ``mode``"""
+    """Options for `mode`. Valid values are ``SHUTDOWN``, ``CONTINUOUS``, and ``ONE_SHOT``"""
 
     pass  # pylint: disable=unnecessary-pass
 
@@ -138,7 +138,7 @@ Mode.add_values(
 
 
 class Resolution(CV):
-    """Options for ``resolution``"""
+    """Options for `resolution` Valid values are ``LOW``, ``MID``, and ``HIGH`` """
 
     pass  # pylint: disable=unnecessary-pass
 
@@ -186,7 +186,11 @@ class BH1750:  # pylint:disable=too-many-instance-attributes
     """
 
     mode = RWBitfields(2, 4)
+    """The capture mode for the sensor. See `Mode` for valid values."""
+
     resolution = RWBitfields(2, 0)
+    """The resolution of the sensor. See `Resolution` for valid values."""
+    """"""
 
     def __init__(self, i2c: I2C, address: int = _BH1750_DEFAULT_ADDRESS) -> None:
         self.i2c_device = i2c_device.I2CDevice(i2c, address)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,4 +6,4 @@
 
 .. automodule:: adafruit_bh1750
    :members:
-   :exclude-members: CV, Resolution, Mode, RWBitfields
+   :exclude-members: CV, RWBitfields


### PR DESCRIPTION
in #9 the OP had trouble figuring out how to set the resolution setting on the sensor. 

A quick look into the docs revealed that both `mode` and `resolution` were undocumented, so I've added docstrings on the register fields and a bit more info into the enum class docs. I also removed the enum classes from the exclude list so that they will get included in the docs page.

Here is a screenshot of how the docs look with a local build with these proposed changes:
![image](https://github.com/user-attachments/assets/a7177ced-1f7a-46fe-8ba3-82466ed83f60)
